### PR TITLE
Sticky navigation bug

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -18,7 +18,7 @@
 	<body>
   <div id="top"/>
   <nav class="nav">
-    <ul class="navigation">
+    <ul class="navigation sticky">
       <li class="content_strategy_nav"><a href="#what_is_content_strategy_section">content strategy</a></li>
       <li><a href="#my_projects_section">my projects</a></li>
       <li><a href="#blog_section">blog</a></li>

--- a/js/main.js
+++ b/js/main.js
@@ -9,35 +9,7 @@ jsPlumb.ready(function() {
 
 $(document).ready(function() {
   onBreakpoint();
-  var stickyNavTop = $('.nav').offset().top;
-
-  var stickyNav = function(){
-    var scrollTop = $(window).scrollTop();       
-    if (scrollTop > stickyNavTop) { 
-        $('.nav').addClass('sticky');
-    } else {
-        $('.nav').removeClass('sticky'); 
-    }
-  };
-
-  stickyNav();
-
-  $(window).scroll(function() {
-    stickyNav();
-  });
-
-//   $('ul.navigation a').click(function() {
-//     $('html, body').animate({
-//   scrollTop: $("#blog_section").offset().top
-// }, 2000);
-//   });
-
 });
-
-
-
-
-
 
 $(window).resize(function(){
   onBreakpoint();


### PR DESCRIPTION
Fix the bug:
`Go to http://contentedstrategy.com/, click the blog link from the
navigation, and you should see that the sticky header overlays the h2.
Click the blog link a second time and it corrects itself.`

Since the sticky navigation is always on top and we're not trying anything more fancy (hide in some areas, show in some areas, or similar things), using only CSS for that effect is possible. 
